### PR TITLE
Add rule proposal tip

### DIFF
--- a/community/micro-contributions/contributor-notes/rule-proposal.json
+++ b/community/micro-contributions/contributor-notes/rule-proposal.json
@@ -1,0 +1,2 @@
+{"topic":"Rule proposal","tip":"A good detection rule targets one specific behavior with a clear, narrow signature, and stays testable by including both a positive test (a sample that should trigger it) and a safe negative test (a similar-looking but benign sample that should not trigger it) — this proves the rule catches real threats without flagging normal activity."}
+


### PR DESCRIPTION
This PR adds a contributor note with a tip on writing useful, testable SkillHawk detection rules — added as community/micro-contributions/contributor-notes/rule-proposal.json.

The tip emphasizes keeping rules narrow and specific to one behavior, and including both a positive test (should trigger) and a safe negative test (should not trigger) to validate accuracy.

Closes #<issue-number>