### PR TITLE
docs(contributor-notes): add finding-title writing tip

### DIFF
--- a/community/micro-contributions/contributor-notes/finding-title-writing.json
+++ b/community/micro-contributions/contributor-notes/finding-title-writing.json
@@ -1,0 +1,4 @@
+{
+  "topic": "Finding title writing",
+  "tip": "State the specific component and vulnerability condition directly in the title (such as 'Unvalidated redirect parameter in auth callback') instead of using generic or sensationalized phrasing."
+}


### PR DESCRIPTION
### Summary
Adds a contributor tip for finding-title writing (#44):
- Created \community/micro-contributions/contributor-notes/finding-title-writing.json\ providing practical guidance on using clear, specific component names and vulnerability mechanisms in finding titles instead of generic or sensational phrasing.

Fixes #44