### PR TITLE
docs: add community tip [MC-032]

### DIFF
--- a/community/micro-contributions/contributor-notes/output-encoding.json
+++ b/community/micro-contributions/contributor-notes/output-encoding.json
@@ -1,0 +1,4 @@
+{
+  "topic": "Output encoding",
+  "tip": "When untrusted text is rendered into HTML, Markdown, terminals, or other structured output, encode or escape it for the destination context instead of treating it as trusted markup."
+}


### PR DESCRIPTION
Closes #86

Adds the prepared `output-encoding.json` contributor note under `community/micro-contributions/contributor-notes/`.