### PR TITLE
docs: add community tip [MC-001]

### DIFF
--- a/community/micro-contributions/contributor-notes/finding-title-clarity.json
+++ b/community/micro-contributions/contributor-notes/finding-title-clarity.json
@@ -1,0 +1,4 @@
+{
+  "topic": "Finding title clarity",
+  "tip": "Prefer short titles that name the risky behavior directly, without exaggerating severity or hiding the concrete action that triggered the finding."
+}


### PR DESCRIPTION
Closes #54

Adds the prepared `finding-title-clarity.json` contributor note under `community/micro-contributions/contributor-notes/`.