### PR TITLE
docs: add CLI message clarity contributor note

### DIFF
--- a/community/micro-contributions/contributor-notes/cli-message-clarity.json
+++ b/community/micro-contributions/contributor-notes/cli-message-clarity.json
@@ -1,0 +1,5 @@
+{
+  "topic": "CLI message clarity",
+  "tip": "CLI findings should lead with rule ID and severity, then show concise evidence and one concrete next action.",
+  "contributed_by": "Mazen-2010-afk"
+}


### PR DESCRIPTION
Adds the cli-message-clarity contributor note per #100.

Closes #100